### PR TITLE
Manual - clarify calling conventions on Win64

### DIFF
--- a/doc/manual/calling-c-and-fortran-code.rst
+++ b/doc/manual/calling-c-and-fortran-code.rst
@@ -800,6 +800,8 @@ but with the correct signature for Windows::
     hn = Array(UInt8, 256)
     err = ccall(:gethostname, stdcall, Int32, (Ptr{UInt8}, UInt32), hn, length(hn))
 
+Note that for 64-bit Windows programs the calling conventions have been unified and even for 
+WINAPI calls there is no need to specify the calling convention.
 For more information, please see the `LLVM Language Reference`_.
 
 .. _LLVM Language Reference: http://llvm.org/docs/LangRef.html#calling-conventions


### PR DESCRIPTION
Clarify that there is no need to specify calling convention on 64 bit windows. Discussed on mailing list [Callback to WinAPI](https://discourse.julialang.org/t/callback-to-winapi/1381).